### PR TITLE
Release action

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,8 +1,9 @@
 name: Publish Packages
 on:
   workflow_dispatch:
-  release:
-    types: [created]
+  # TODO: RE-enable, just disabling for testing actions in my own fork
+  # release:
+  #   types: [created]
 jobs:
   publish-packages:
     runs-on: ubuntu-22.04

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,19 @@
+name: Version Bump
+on:
+  workflow_dispatch:
+jobs:
+  publish-packages:
+    runs-on: ubuntu-22.04
+    # permissions:
+    #   contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - name: Update version bump
+        run: GH_TOKEN=${{ secrets.GITHUB_TOKEN }} npm run version-bump -- --yes

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -4,12 +4,13 @@ on:
 jobs:
   publish-packages:
     runs-on: ubuntu-22.04
-    # permissions:
-    #   contents: write
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          fetch-detph: '0' # Need the history to properly generate the changelog
           ref: ${{ github.ref }}
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-detph: '0' # Need the history to properly generate the changelog
+          fetch-depth: '0' # Need the history to properly generate the changelog
           ref: ${{ github.ref }}
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,5 +15,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18.x'
+      - name: Configure `git`
+        run: |
+          git config --global user.email "ci@deephaven.io"
+          git config --global user.name "deephaven-internal"
       - name: Update version bump
         run: GH_TOKEN=${{ secrets.GITHUB_TOKEN }} npm run version-bump -- --yes


### PR DESCRIPTION
- Tested against my own repository, there are two main issues:
  - Can't restrict who can trigger the workflow_dispatch, other than just who can write to the repo
  - Need to use GITHUB_TOKEN of user that can override branch protection settings (the default does not). I'm hesitant to automate that as it could potentially be abused.
